### PR TITLE
[Feat] Dto 생성

### DIFF
--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsListResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsListResponseDto.java
@@ -1,0 +1,21 @@
+package org.zerock.likelion.imfinebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsListResponseDto {
+    // 뉴스 전체 목록 보기용
+    private UUID id;
+    private LocalDate date;
+    private String title;
+    private String summary;
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsResponseDto.java
@@ -1,0 +1,27 @@
+package org.zerock.likelion.imfinebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsResponseDto {
+    private UUID id;
+    private String originalUrl;
+    private LocalDate date;
+    private String reporter;
+    private String title;
+    private String summary;
+    private String content;
+    private List<NewsTermResponseDto> terms;
+    private List<QuizResponseDto> quizzes;
+
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsTermResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsTermResponseDto.java
@@ -1,0 +1,16 @@
+package org.zerock.likelion.imfinebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsTermResponseDto {
+    private Long id;
+    private String term;
+    private String meaning;
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/QuizResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/QuizResponseDto.java
@@ -1,0 +1,16 @@
+package org.zerock.likelion.imfinebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizResponseDto {
+    private Long id;
+    private String question;
+    // answer는 응답에서 제외 (정답을 바로 알려주지 않기 위해)
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/UserAnswerRequestDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/UserAnswerRequestDto.java
@@ -1,0 +1,16 @@
+package org.zerock.likelion.imfinebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAnswerRequestDto {
+    private Long userId;
+    private Long quizId;
+    private Boolean answer;
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/UserAnswerResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/UserAnswerResponseDto.java
@@ -1,0 +1,18 @@
+package org.zerock.likelion.imfinebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAnswerResponseDto {
+    private Long id;
+    private Long userId;
+    private Long quizId;
+    private Boolean userAnswer;
+    private Boolean isCorrect;  // 정답 여부
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/entity/UserAnswerEntity.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/entity/UserAnswerEntity.java
@@ -29,4 +29,7 @@ public class UserAnswerEntity {
     @Column
     private Boolean answer;
 
+    @Column(name="is_correct")
+    private Boolean isCorrect;
+
 }


### PR DESCRIPTION
closed #2 
closed #3 

### News 관련 Dto
- `NewsResponseDto`: 뉴스를 크롤링 시 바로 DB에 저장되기 때문에 랜딩 페이지에서 '알쏭달쏭 경제 돋보기'를 눌렀을 때 띄울 뉴스를 받아오기 위한 Dto
    - hasAnswered 필드를 추가하여 사용자가 이미 본 뉴스인지 판단
- `NewsListResponseDto`: '알쏭달쏭 경제 돋보기'에서 '목록보기'를 눌렀을 때 뉴스들을 간략하게 띄우기 위한 Dto
- `NewsTermResponseDto`: 뉴스를 띄울 때 '알쏭 용어 한눈에'에 띄울 뉴스 용어를 위한 Dto

### Quiz 관련 Dto
- `QuizResponseDto`: 퀴즈 또한 크롤링 시 DB에 바로 저장되기 때문에 '알쏭달쏭 경제 돋보기' > '알쏭달쏭 경제 퀴즈 풀기'를 눌렀을 때 퀴즈를 띄우기 위한 Dto
    - 퀴즈를 띄운 즉시 정답이 표시 되지 않기 위해 answer 속성은 미포함 (추후에 테스팅 하면서 변경 가능성 유)

### User 관련 Dto
- 회원가입/로그인 로직을 이번 미니 프로젝트에서 포한 시키지 않았기 때문에 User관련 Dto는 퀴즈를 풀고 정답을 생성하는 Dto밖에 없다
- `UserAnswerRequestDto`: 사용자가 답안을 제출할 때 사용
- `UserAnswerResponseDto`: 사용자의 답안 제출 결과를 반환할 때 사용. 정답 여부(isCorrect)를 추가