### PR TITLE
[Feat] News API

### DIFF
--- a/src/main/java/org/zerock/likelion/imfinebackend/controller/NewsController.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/controller/NewsController.java
@@ -1,0 +1,38 @@
+package org.zerock.likelion.imfinebackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zerock.likelion.imfinebackend.dto.NewsListResponseDto;
+import org.zerock.likelion.imfinebackend.dto.NewsResponseDto;
+import org.zerock.likelion.imfinebackend.service.NewsService;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/news")
+@RequiredArgsConstructor
+public class NewsController {
+    private final NewsService newsService;
+
+    // 오늘의 뉴스 읽기
+    @GetMapping("/today")
+    public ResponseEntity<NewsResponseDto> getTodayNews(
+            @RequestParam Long userId) {
+        return ResponseEntity.ok(newsService.getTodayNews(userId));
+    }
+
+    // UUID로 특정 뉴스 조회 (목록보기 > 뉴스 선택 시 필요)
+    @GetMapping("/{newsId}")
+    public ResponseEntity<NewsResponseDto> getNews(
+            @PathVariable UUID newsId) {
+        return ResponseEntity.ok(newsService.getNews(newsId));
+    }
+
+    // 뉴스 목록보기
+    @GetMapping("/list")
+    public ResponseEntity<List<NewsListResponseDto>> getAllNews() {
+        return ResponseEntity.ok(newsService.getAllNews());
+    }
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsResponseDto.java
@@ -23,5 +23,6 @@ public class NewsResponseDto {
     private String content;
     private List<NewsTermResponseDto> terms;
     private List<QuizResponseDto> quizzes;
+    private boolean hasAnswered;
 
 }

--- a/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsResponseDto.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/dto/NewsResponseDto.java
@@ -23,6 +23,4 @@ public class NewsResponseDto {
     private String content;
     private List<NewsTermResponseDto> terms;
     private List<QuizResponseDto> quizzes;
-    private boolean hasAnswered;
-
 }

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/NewsRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/NewsRepository.java
@@ -1,0 +1,23 @@
+package org.zerock.likelion.imfinebackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.zerock.likelion.imfinebackend.entity.NewsEntity;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface NewsRepository extends JpaRepository<NewsEntity, UUID> {
+    // 특정 주의 뉴스 중 사용자가 풀지 않은 퀴즈가 있는 뉴스 찾기
+    @Query("SELECT DISTINCT n FROM NewsEntity n " +
+    "LEFT JOIN n.quizzes q " +
+    "LEFT JOIN q.userAnswers ua " +
+    "WHERE n.date BETWEEN :weekStart AND :weekEnd " +
+    "AND (ua.user.id IS NULL OR ua.user.id != :userId)")
+    List<NewsEntity> findUnreadNewsInWeek(
+            @Param("weekStart")LocalDate weekStart,
+            @Param("weekEnd") LocalDate weekEnd,
+            @Param("userId") Long userId);
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/NewsRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/NewsRepository.java
@@ -7,17 +7,18 @@ import org.zerock.likelion.imfinebackend.entity.NewsEntity;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface NewsRepository extends JpaRepository<NewsEntity, UUID> {
-    // 특정 주의 뉴스 중 사용자가 풀지 않은 퀴즈가 있는 뉴스 찾기
-    @Query("SELECT DISTINCT n FROM NewsEntity n " +
-    "LEFT JOIN n.quizzes q " +
-    "LEFT JOIN q.userAnswers ua " +
-    "WHERE n.date BETWEEN :weekStart AND :weekEnd " +
-    "AND (ua.user.id IS NULL OR ua.user.id != :userId)")
-    List<NewsEntity> findUnreadNewsInWeek(
-            @Param("weekStart")LocalDate weekStart,
-            @Param("weekEnd") LocalDate weekEnd,
-            @Param("userId") Long userId);
+    // 특정 날짜의 뉴스 조회
+    @Query("SELECT n FROM NewsEntity n WHERE n.date = :date")
+    Optional<NewsEntity> findNewsByDate(@Param("date") LocalDate date);
+
+    // 특정 사용자가 특정 뉴스의 퀴즈를 풀었는지 확인
+    @Query("SELECT CASE WHEN COUNT(ua) > 0 THEN true ELSE false END " +
+            "FROM UserAnswerEntity ua " +
+            "WHERE ua.user.id = :userId " +
+            "AND ua.quiz.news.id = :newsId")
+    boolean hasUserAnsweredQuiz(@Param("userId") Long userId, @Param("newsId") UUID newsId);
 }

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/NewsRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/NewsRepository.java
@@ -11,14 +11,15 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface NewsRepository extends JpaRepository<NewsEntity, UUID> {
-    // 특정 날짜의 뉴스 조회
-    @Query("SELECT n FROM NewsEntity n WHERE n.date = :date")
-    Optional<NewsEntity> findNewsByDate(@Param("date") LocalDate date);
-
-    // 특정 사용자가 특정 뉴스의 퀴즈를 풀었는지 확인
-    @Query("SELECT CASE WHEN COUNT(ua) > 0 THEN true ELSE false END " +
-            "FROM UserAnswerEntity ua " +
-            "WHERE ua.user.id = :userId " +
-            "AND ua.quiz.news.id = :newsId")
-    boolean hasUserAnsweredQuiz(@Param("userId") Long userId, @Param("newsId") UUID newsId);
+    // 이번 주의 안 읽은 뉴스 조회
+    @Query("SELECT DISTINCT n FROM NewsEntity n " +
+            "LEFT JOIN n.quizzes q " +
+            "LEFT JOIN q.userAnswers ua " +
+            "WHERE n.date BETWEEN :weekStart AND :weekEnd " +
+            "AND (ua.user.id IS NULL OR ua.user.id != :userId) " +
+            "ORDER BY n.date ASC")  // 날짜순 정렬 추가
+    List<NewsEntity> findUnreadNewsInWeek(
+            @Param("weekStart") LocalDate weekStart,
+            @Param("weekEnd") LocalDate weekEnd,
+            @Param("userId") Long userId);
 }

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/QuizRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/QuizRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.likelion.imfinebackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.likelion.imfinebackend.entity.QuizEntity;
+
+public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/UserAnswerRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/UserAnswerRepository.java
@@ -1,0 +1,8 @@
+package org.zerock.likelion.imfinebackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.likelion.imfinebackend.entity.UserAnswerEntity;
+
+public interface UserAnswerRepository extends JpaRepository<UserAnswerEntity, Long> {
+
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/UserRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.likelion.imfinebackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.likelion.imfinebackend.entity.UserEntity;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/service/NewsService.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/service/NewsService.java
@@ -26,7 +26,7 @@ public class NewsService {
 
     // 오늘의 뉴스 읽기 (이번 주 뉴스 중 안읽은 뉴스 랜덤 선택)
     // 읽은지 여부는 퀴즈 응시 여부로 판단
-    public List<NewsListResponseDto> getUnreadNewsList(Long userId) {
+    public NewsResponseDto getTodayNews(Long userId) {
         LocalDate now = LocalDate.now();
         LocalDate weekStart = now.with(WeekFields.of(Locale.getDefault()).dayOfWeek(), 1);
         LocalDate weekEnd = weekStart.plusDays(6);
@@ -44,6 +44,31 @@ public class NewsService {
         NewsEntity todayNews = unreadNews.get(todayIndex);
 
         return convertToNewsDto(todayNews);
+    }
+
+    // 뉴스 전체 목록 조회 ('목록보기' 버튼)
+    public List<NewsListResponseDto> getAllNews() {
+        return newsRepository.findAll().stream()
+                .map(this::convertToNewsListDto)
+                .sorted((a, b) -> b.getDate().compareTo(a.getDate())) // 최신 날짜순 정렬
+                .collect(Collectors.toList());
+    }
+
+    // UUID로 뉴스 접근 (목록에서 선택 시 필요)
+    public NewsResponseDto getNews(UUID newsId) {
+        NewsEntity news = newsRepository.findById(newsId)
+                .orElseThrow(() -> new RuntimeException("News not found"));
+        return convertToNewsDto(news);
+    }
+
+    // Entity -> NewsListResponseDto 변환
+    private NewsListResponseDto convertToNewsListDto(NewsEntity news) {
+        return NewsListResponseDto.builder()
+                .id(news.getId())
+                .date(news.getDate())
+                .title(news.getTitle())
+                .summary(news.getSummary())
+                .build();
     }
 
     // Entity -> NewsResponseDto로 변환
@@ -74,5 +99,6 @@ public class NewsService {
                 .terms(terms)
                 .quizzes(quizzes)
                 .build();
-    }
+        }
+
 }

--- a/src/main/java/org/zerock/likelion/imfinebackend/service/NewsService.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/service/NewsService.java
@@ -1,0 +1,70 @@
+package org.zerock.likelion.imfinebackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.likelion.imfinebackend.dto.NewsListResponseDto;
+import org.zerock.likelion.imfinebackend.dto.NewsResponseDto;
+import org.zerock.likelion.imfinebackend.dto.NewsTermResponseDto;
+import org.zerock.likelion.imfinebackend.dto.QuizResponseDto;
+import org.zerock.likelion.imfinebackend.entity.NewsEntity;
+import org.zerock.likelion.imfinebackend.repository.NewsRepository;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsService {
+    private final NewsRepository newsRepository;
+
+    // 오늘의 뉴스 읽기 (이번 주 뉴스 중 안읽은 뉴스 랜덤 선택)
+    // 읽은지 여부는 퀴즈 응시 여부로 판단
+    public List<NewsListResponseDto> getUnreadNewsList(Long userId) {
+        LocalDate today = LocalDate.now();
+
+        NewsEntity todayNews = newsRepository.findNewsByDate(today)
+                .orElseThrow(() -> new RuntimeException("오늘의 뉴스가 존재하지 않습니다"));
+
+        boolean hasAnswered = newsRepository.hasUserAnsweredQuiz(userId, todayNews.getId());
+
+        return convertToNewsDto(todayNews, hasAnswered);
+    }
+
+    // Entity -> NewsResponseDto로 변환
+    private NewsResponseDto convertToNewsDto(NewsEntity news, boolean hasAnswered) {
+        List<NewsTermResponseDto> terms = news.getNewsTerms().stream()
+                .map(term -> NewsTermResponseDto.builder()
+                        .id(term.getId())
+                        .term(term.getTerm())
+                        .meaning(term.getMeaning())
+                        .build())
+                .collect(Collectors.toList());
+
+        List<QuizResponseDto> quizzes = news.getQuizzes().stream()
+                .map(quiz -> QuizResponseDto.builder()
+                        .id(quiz.getId())
+                        .question(quiz.getQuestion())
+                        .build())
+                .collect(Collectors.toList());
+
+        return NewsResponseDto.builder()
+                .id(news.getId())
+                .originalUrl(news.getOriginalUrl())
+                .date(news.getDate())
+                .reporter(news.getReporter())
+                .title(news.getTitle())
+                .summary(news.getSummary())
+                .content(news.getContent())
+                .terms(terms)
+                .quizzes(quizzes)
+                .hasAnswered(hasAnswered)
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/service/UserAnswerService.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/service/UserAnswerService.java
@@ -1,0 +1,21 @@
+package org.zerock.likelion.imfinebackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.likelion.imfinebackend.dto.UserAnswerRequestDto;
+import org.zerock.likelion.imfinebackend.dto.UserAnswerResponseDto;
+import org.zerock.likelion.imfinebackend.entity.UserEntity;
+import org.zerock.likelion.imfinebackend.repository.QuizRepository;
+import org.zerock.likelion.imfinebackend.repository.UserAnswerRepository;
+import org.zerock.likelion.imfinebackend.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAnswerService {
+    private final UserAnswerRepository userAnswerRepository;
+    private final UserRepository userRepository;
+    private final QuizRepository quizRepository;
+
+}


### PR DESCRIPTION
closed #4 
- NewsController
    - `/news/today`: 알쏭달쏭 경제 돋보기 이동 시 오늘의 뉴스
        - Request Param으로 userId값 필요 (퀴즈 응시 여부 확인을 위해)
    - `/news/{newsId}`: '목록보기' 에서 뉴스 선택 시 뉴스 띄우기
    - `/news/list`: '목록보기'에서 전체 뉴스 띄우기
- Repository
    - QuizRepository 생성
    - UserRepository 생성
    - UserAnswerRepository 생성