### PR TITLE
[Feat] quiz API 구현

### DIFF
--- a/src/main/java/org/zerock/likelion/imfinebackend/controller/QuizController.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/controller/QuizController.java
@@ -1,0 +1,23 @@
+package org.zerock.likelion.imfinebackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zerock.likelion.imfinebackend.dto.QuizResponseDto;
+import org.zerock.likelion.imfinebackend.service.QuizService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/quiz")
+@RequiredArgsConstructor
+public class QuizController {
+    private final QuizService quizService;
+
+    // UUID로 특정 뉴스에 해당하는 퀴즈 반환
+    @GetMapping("/{newsId}")
+    public ResponseEntity<QuizResponseDto> getQuiz(
+            @PathVariable UUID newsId) {
+        return ResponseEntity.ok(quizService.getQuiz(newsId));
+    }
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/controller/UserAnswerController.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/controller/UserAnswerController.java
@@ -1,0 +1,24 @@
+package org.zerock.likelion.imfinebackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zerock.likelion.imfinebackend.dto.UserAnswerRequestDto;
+import org.zerock.likelion.imfinebackend.dto.UserAnswerResponseDto;
+import org.zerock.likelion.imfinebackend.service.UserAnswerService;
+
+
+@RestController
+@RequestMapping("/answer")
+@RequiredArgsConstructor
+public class UserAnswerController {
+    private final UserAnswerService userAnswerService;
+
+    // UUID로 특정 뉴스에 해당하는 퀴즈 사용자 답 받기
+    @PostMapping()
+    public ResponseEntity<UserAnswerResponseDto> postUserAnswer(
+            @RequestBody UserAnswerRequestDto userAnswerRequestDto
+    ) {
+        return ResponseEntity.ok(userAnswerService.postUserAnswer(userAnswerRequestDto));
+    }
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/entity/UserAnswerEntity.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/entity/UserAnswerEntity.java
@@ -1,15 +1,16 @@
 package org.zerock.likelion.imfinebackend.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
 
 @Entity
 @Table(name="user_answer")
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class UserAnswerEntity {
 
     @Id

--- a/src/main/java/org/zerock/likelion/imfinebackend/repository/QuizRepository.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/repository/QuizRepository.java
@@ -3,5 +3,9 @@ package org.zerock.likelion.imfinebackend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.zerock.likelion.imfinebackend.entity.QuizEntity;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
+    Optional<QuizEntity> findByNews_Id(UUID newsId);
 }

--- a/src/main/java/org/zerock/likelion/imfinebackend/service/QuizService.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/service/QuizService.java
@@ -1,0 +1,31 @@
+package org.zerock.likelion.imfinebackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.likelion.imfinebackend.dto.QuizResponseDto;
+import org.zerock.likelion.imfinebackend.entity.QuizEntity;
+import org.zerock.likelion.imfinebackend.repository.QuizRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizService {
+    private final QuizRepository quizRepository;
+
+    // UUID로 특정 뉴스에 해당하는 퀴즈 반환
+    public QuizResponseDto getQuiz(UUID newsId) {
+        QuizEntity quiz = quizRepository.findByNews_Id(newsId)
+                .orElseThrow(() -> new RuntimeException("quiz not found"));
+        return convertToQuizResponseDTO(quiz);
+    }
+
+    private QuizResponseDto convertToQuizResponseDTO(QuizEntity quiz) {
+        return QuizResponseDto.builder()
+                .id(quiz.getId())
+                .question(quiz.getQuestion())
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/likelion/imfinebackend/service/UserAnswerService.java
+++ b/src/main/java/org/zerock/likelion/imfinebackend/service/UserAnswerService.java
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.likelion.imfinebackend.dto.UserAnswerRequestDto;
 import org.zerock.likelion.imfinebackend.dto.UserAnswerResponseDto;
+import org.zerock.likelion.imfinebackend.entity.QuizEntity;
+import org.zerock.likelion.imfinebackend.entity.UserAnswerEntity;
 import org.zerock.likelion.imfinebackend.entity.UserEntity;
 import org.zerock.likelion.imfinebackend.repository.QuizRepository;
 import org.zerock.likelion.imfinebackend.repository.UserAnswerRepository;
 import org.zerock.likelion.imfinebackend.repository.UserRepository;
+
 
 @Service
 @RequiredArgsConstructor
@@ -18,4 +21,36 @@ public class UserAnswerService {
     private final UserRepository userRepository;
     private final QuizRepository quizRepository;
 
+    public UserAnswerResponseDto postUserAnswer(UserAnswerRequestDto userAnswerRequestDto) {
+        QuizEntity quiz = quizRepository.findById(userAnswerRequestDto.getQuizId())
+                .orElseThrow(() -> new RuntimeException("quiz not found"));
+
+        UserEntity user = userRepository.findById(userAnswerRequestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("user not found"));
+
+        Boolean isCorrect = userAnswerRequestDto.getAnswer().equals(quiz.getAnswer());
+
+        // UserAnswer 엔티티 생성 후 DB에 저장
+        UserAnswerEntity userAnswer = UserAnswerEntity.builder()
+                .user(user)
+                .quiz(quiz)
+                .answer(userAnswerRequestDto.getAnswer())
+                .isCorrect(isCorrect)
+                .build();
+
+        userAnswer = userAnswerRepository.save(userAnswer);
+
+        return convertToUserAnswerResponseDTO(userAnswer);
+    }
+
+    private UserAnswerResponseDto convertToUserAnswerResponseDTO(UserAnswerEntity userAnswer) {
+        return UserAnswerResponseDto.builder()
+                .id(userAnswer.getId())
+                .userId(userAnswer.getUser().getId())
+                .quizId(userAnswer.getQuiz().getId())
+                .userAnswer(userAnswer.getAnswer())
+                .isCorrect(userAnswer.getIsCorrect())
+                .build();
+    }
 }
+


### PR DESCRIPTION
closed #9 

- QuizController
    - /quiz/{newsId} : 해당 뉴스의 퀴즈 정보 
- UserAnswerController
    - /answer : 퀴즈 풀기, requestBody 값으로 quiz와 user 판별 후 answer의 정답 유무를 더해 반환
 - UserAnswerEntity
    - save()를 위해 @builder 추가 
- QuizRepository
   - findByNews_Id() 추가
- Service
    - QuizService : getQuiz() 구현
    - UserAnswerService : postUserAnswer() 구현
